### PR TITLE
do not dispose runspace

### DIFF
--- a/ProfileAsync.psd1
+++ b/ProfileAsync.psd1
@@ -4,7 +4,7 @@
 RootModule = 'ProfileAsync.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.0'
+ModuleVersion = '0.2.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -125,4 +125,3 @@ PrivateData = @{
 # DefaultCommandPrefix = ''
 
 }
-

--- a/public/Import-ProfileAsync.ps1
+++ b/public/Import-ProfileAsync.ps1
@@ -128,8 +128,6 @@ function Import-ProfileAsync
                 $_ | Out-String | Write-Host -ForegroundColor Red
             }
 
-            $PowerShell.Runspace.Dispose()
-            $PowerShell.Dispose()
             Unregister-Event $SourceIdentifier
             Get-Job $SourceIdentifier | Remove-Job
 


### PR DESCRIPTION
See triage in #4 

Turns out that any scriptblock created in the async section is associated with the runspace, and may well fail in some contexts - e.g. when events are involved (as is the case with custom PSReadLine handlers)