### PR TITLE
Test output

### DIFF
--- a/ProfileAsync.psd1
+++ b/ProfileAsync.psd1
@@ -4,7 +4,7 @@
 RootModule = 'ProfileAsync.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.3.0'
+ModuleVersion = '0.3.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/public/Import-ProfileAsync.ps1
+++ b/public/Import-ProfileAsync.ps1
@@ -129,10 +129,18 @@ function Import-ProfileAsync
             }
 
             $Formats = $Powershell.Runspace.InitialSessionState.Formats
-            Update-FormatData -PrependPath $Formats.FileName
+            $FormatFiles = $Formats.FileName | Where-Object {$_ -and (Test-Path $_)}
+            if ($FormatFiles)
+            {
+                Update-FormatData -PrependPath $FormatFiles
+            }
 
             $Types = $Powershell.Runspace.InitialSessionState.Types
-            Update-TypeData -PrependPath $Types.FileName
+            $TypeFiles = $Types.FileName | Where-Object {$_ -and (Test-Path $_)}
+            if ($TypeFiles)
+            {
+                Update-TypeData -PrependPath $TypeFiles
+            }
 
             Unregister-Event $SourceIdentifier
             Get-Job $SourceIdentifier | Remove-Job


### PR DESCRIPTION
In #8 we reimport format and type data. However, `InitialSessionState.Formats` includes format data that used to be provided by ps1xml files in PSHOME, but are now internal. This data still has the legacy filenames attached even though they don't exist on disk.

These filenames result in an error that is not visible to the user, but shows up in the test output.

This PR cleans that up to only re-import format and type data that is backed by a file that exists.