### PR TITLE
feat: generalize test container runner to support podman

### DIFF
--- a/tests/ProfileAsync.Tests.ps1
+++ b/tests/ProfileAsync.Tests.ps1
@@ -2,7 +2,7 @@ BeforeAll {
     $TestRoot = $PSScriptRoot
     $ModuleBase = $PSScriptRoot | Split-Path
     $PesterBase = (Get-Module Pester).ModuleBase
-    $ContainerRunner = 'docker', 'podman' | ForEach-Object { Get-Command $_ -ErrorAction SilentlyContinue } | Select-Object -Expand Name
+    $ContainerRunner = 'docker', 'podman' | ForEach-Object { Get-Command $_ -ErrorAction SilentlyContinue } | Select-Object -First 1 -Expand Name
     $Containers = @{}
 
     function Test


### PR DESCRIPTION
(original pr committed through `gh using the gh pr create --fill` which did not create a body here)

This code change adds support for the tests to check through docker and podman to see which container runner to use.
In every case I've found the statement of podman being a drop in replacement for docker certainly holds, this case included.

Then I replaced all calls to docker with this

```ps1
& $ContainerRunner ....
```