### PR TITLE
Suppress output in non-interactive calls - fix for the fix

### DIFF
--- a/ProfileAsync.psd1
+++ b/ProfileAsync.psd1
@@ -4,7 +4,7 @@
 RootModule = 'ProfileAsync.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.4.0'
+ModuleVersion = '0.4.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/public/Import-ProfileAsync.ps1
+++ b/public/Import-ProfileAsync.ps1
@@ -108,13 +108,13 @@ function Import-ProfileAsync
 
     $SourceIdentifier = "__ProfileAsyncCleanup__" + [guid]::NewGuid()
     $HandlerParams = @{
-        MessageData = $AsyncResult, $Silent
+        MessageData = $AsyncResult, $Silent, $VerbosePreference
         InputObject = $Powershell
         EventName = "InvocationStateChanged"
         SourceIdentifier = $SourceIdentifier
     }
     $null = Register-ObjectEvent @HandlerParams -Action {
-        $AsyncResult, $Silent = $Event.MessageData
+        $AsyncResult, $Silent, $VerbosePreference = $Event.MessageData
         $Powershell = $Event.Sender
         $SourceIdentifier = $EventSubscriber.SourceIdentifier
 
@@ -152,7 +152,7 @@ function Import-ProfileAsync
             Unregister-Event $SourceIdentifier
             Get-Job $SourceIdentifier | Remove-Job
 
-            if (-not $Silent)
+            if ($VerbosePreference -eq 'Continue' -and -not $Silent)
             {
                 $State = [string]$Powershell.InvocationStateInfo.State
                 $Msg = "VERBOSE: Asynchronous execution $($State.ToLower())"


### PR DESCRIPTION
#12 included a bug - the "verbose" output on completion was not respecting VerbosePreference.